### PR TITLE
default is_active=true for Languages and CustomerCategories

### DIFF
--- a/app/models/customer_category.rb
+++ b/app/models/customer_category.rb
@@ -5,7 +5,7 @@
 #  id                 :bigint           not null, primary key
 #  appointment_prefix :string
 #  display_value      :string
-#  is_active          :boolean
+#  is_active          :boolean          default(TRUE)
 #  sort_order         :bigint
 #  telephone_prefix   :string
 #  video_prefix       :string
@@ -34,6 +34,8 @@ class CustomerCategory < ApplicationRecord
   validates :appointment_prefix, length: {maximum: 10}
 
   scope :active, -> { where(is_active: true) }
+
+  attribute :is_active, :boolean, default: true
 
   def modality_prefix(modality)
     case modality

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -3,7 +3,7 @@
 # Table name: languages
 #
 #  id         :bigint           not null, primary key
-#  is_active  :boolean
+#  is_active  :boolean          default(TRUE)
 #  name       :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -34,6 +34,8 @@ class Language < ApplicationRecord
   has_many :pay_rates, through: :pay_rate_languages
 
   validates :name, presence: true
+
+  attribute :is_active, :boolean, default: true
 
   def toggle_active!
     update! is_active: !is_active

--- a/db/migrate/20230421125114_add_default_value_to_is_active_in_languages.rb
+++ b/db/migrate/20230421125114_add_default_value_to_is_active_in_languages.rb
@@ -1,0 +1,9 @@
+class AddDefaultValueToIsActiveInLanguages < ActiveRecord::Migration[7.0]
+  def up
+    change_column :languages, :is_active, :boolean, default: true
+  end
+
+  def down
+    change_column :languages, :is_active, :boolean, default: nil
+  end
+end

--- a/db/migrate/20230421125156_add_default_value_to_is_active_in_customer_categories.rb
+++ b/db/migrate/20230421125156_add_default_value_to_is_active_in_customer_categories.rb
@@ -1,0 +1,9 @@
+class AddDefaultValueToIsActiveInCustomerCategories < ActiveRecord::Migration[7.0]
+  def up
+    change_column :customer_categories, :is_active, :boolean, default: true
+  end
+
+  def down
+    change_column :customer_categories, :is_active, :boolean, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_20_011859) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_21_125156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -371,7 +371,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_20_011859) do
     t.string "video_prefix"
     t.bigint "backport_id"
     t.bigint "sort_order"
-    t.boolean "is_active"
+    t.boolean "is_active", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "account_id"
@@ -459,7 +459,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_20_011859) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "account_id", null: false
-    t.boolean "is_active"
+    t.boolean "is_active", default: true
     t.index ["account_id"], name: "index_languages_on_account_id"
   end
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes made in this PR along with any context that may be helpful for the reviewer. -->
- default is_active=true for Languages and CustomerCategories
- added a db constraint to default to true, 
- also added default attribute in the model so if you do `Customer.new` and `CutomerCategory.new` `is_active` will default to `true` and will reflect in the UI  check box



## Proof



<img width="651" alt="Screen Shot 2023-04-21 at 9 00 29 PM" src="https://user-images.githubusercontent.com/2928409/233646715-23d1a1ae-df56-42c4-bbca-642f9a00394f.png">
<img width="851" alt="Screen Shot 2023-04-21 at 9 02 17 PM" src="https://user-images.githubusercontent.com/2928409/233646808-dfbdcd54-cfd8-456e-89ce-6f201245df59.png">



Uploading Screen Recording 2023-04-21 at 9.06.08 PM.mov…


