### PR TITLE
style: appointment edit page show ref number instead of id

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,5 +1,4 @@
 <%= content_for :title, t("shared.scaffold.edit.title", model: "Appointment") %>
-<%= content_for :title, "Appointment ##{@appointment.id}" %>
 
 <div class="flex flex-1 flex-col md:pl-64">
   <main class="flex-1">
@@ -7,13 +6,13 @@
       <div class="mx-auto max-w-7xl px-4 sm:px-6 md:px-6">
           <div class="px-4 sm:px-6 lg:px-8">
             <div class="sm:flex sm:items-center pb-6">
-                <div class="sm:flex-auto"> 
+                <div class="sm:flex-auto">
                   <h1 class="text-xl font-semibold text-gray-900">
                     <%= link_to "Appointments", appointments_path, class: "text-tokanisecondary-500" %>
                       <span class="text-gray-400 font-light mx-2">\</span>
-                      <%= @appointment.id %>
+                      <%= @appointment.ref_number %>
                   </h1>
-                </div>   
+                </div>
               </div>
               <div class="p-8 bg-white rounded shadow">
                 <%= render partial: "form", locals: { appointment: @appointment, interpreters: @interpreters, requestors: @requestors, providers: @providers, recipients: @recipients, account_customers: @account_customers, customer: @customer, sites: @sites, departments: @departments, languages: @languages } %>


### PR DESCRIPTION
## Description
Updated the Appointments Edit page to show the ref number instead of the appointment ID


## Proof
![image](https://user-images.githubusercontent.com/24237429/233776769-785627a8-8a18-4726-959f-e02d175e2d6b.png)



## Review Context
Went ahead and only changed the view for now, but I was thinking of using the ref numbers as [URL slugs](https://github.com/norman/friendly_id) for appointments. Let me know your thoughts on this
