### PR TITLE
dont allow for agencies and customers to create duplicate Recipients

### DIFF
--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -18,6 +18,7 @@
 # Indexes
 #
 #  index_recipients_on_customer_id  (customer_id)
+#  unique_email_customer_id         (email,customer_id) UNIQUE
 #
 # Foreign Keys
 #
@@ -37,6 +38,8 @@ class Recipient < ApplicationRecord
   validates :first_name, presence: {message: "field is required"}
   validates :last_name, presence: {message: "field is required"}
   validates :customer_id, presence: {message: "field is required"}
+
+  validates_uniqueness_of :email, scope: :customer_id
 
   def view_name
     "#{first_name} #{last_name}"

--- a/db/migrate/20230424090204_add_unique_index_to_recipients.rb
+++ b/db/migrate/20230424090204_add_unique_index_to_recipients.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexToRecipients < ActiveRecord::Migration[7.0]
+  def up
+    add_index :recipients, [:email, :customer_id], unique: true, name: "unique_email_customer_id"
+  end
+
+  def down
+    remove_index :recipients, name: "unique_email_customer_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_21_222517) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_24_090204) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -717,6 +717,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_21_222517) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_recipients_on_customer_id"
+    t.index ["email", "customer_id"], name: "unique_email_customer_id", unique: true
   end
 
   create_table "report_customers", force: :cascade do |t|

--- a/test/fixtures/recipients.yml
+++ b/test/fixtures/recipients.yml
@@ -19,6 +19,7 @@
 # Indexes
 #
 #  index_recipients_on_customer_id  (customer_id)
+#  unique_email_customer_id         (email,customer_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/test/models/recipient_test.rb
+++ b/test/models/recipient_test.rb
@@ -18,6 +18,7 @@
 # Indexes
 #
 #  index_recipients_on_customer_id  (customer_id)
+#  unique_email_customer_id         (email,customer_id) UNIQUE
 #
 # Foreign Keys
 #


### PR DESCRIPTION
## Description
- resolves https://github.com/SuperDupr/tokani/issues/408
- add unique constraint to `recipients.email + customer_id combo` 
- also added a constraint in model level

NOTE:
when running this migration, make sure there are no existing duplicate email + customer_id in the database
any existing duplicate records will cause an error when we try to add the constraint or index.


https://user-images.githubusercontent.com/2928409/233953581-c9ba4fae-789b-45db-a7bb-d38a88a822be.mov

