### PR TITLE
Feat: Ability for customers & agencies to open appointments

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -109,11 +109,10 @@ class AppointmentsController < ApplicationController
 
   # GET /appointments/1 or /appointments/1.json
   def show
-    statuses = AppointmentPolicy::AppointmentStatusesScope.new(current_account_user, AppointmentStatus).resolve
+    scoped_statuses = AppointmentPolicy::AppointmentStatusesScope.new(current_account_user, AppointmentStatus).resolve
 
-    statuses.reject! { |stat| stat == :cancel } if @appointment.can_cancel?
-
-    @appointment_statuses = statuses
+    # Fetched from AppointmentWorkflow
+    @appointment_statuses = @appointment.allowed_actions(scoped_statuses)
   end
 
   # GET /appointments/new
@@ -253,15 +252,18 @@ class AppointmentsController < ApplicationController
   end
 
   def update_status
-    @appt_status = @appointment.appointment_statuses.new(
-      name: params.dig(:appointment, :status),
-      user_id: current_account.owner_id
-    )
+    status = params[:status]
+
+    authorize @appointment, :"#{status}?"
 
     respond_to do |format|
-      @appt_status.save ?
-        format.json { render json: {status: @appointment.status} } :
-        format.json { render json: {error: "Something went wrong while updating appointment's status!"} }
+      if @appointment.send(:"#{status}!")
+        format.html { redirect_to @appointment, notice: "Appointment status successfully updated." }
+        format.json { render :show, status: :ok, location: @appointment }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @appointment.errors, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/models/appointment_status.rb
+++ b/app/models/appointment_status.rb
@@ -24,10 +24,11 @@ class AppointmentStatus < ApplicationRecord
   # after_update_commit -> { broadcast_replace_later_to self }
   # after_destroy_commit -> { broadcast_remove_to :appointment_statuses, target: dom_id(self, :index) }
 
-  # Used in dropdown
-  ACTIONS = {
-    :cancel => :cancelled
-  }
+  ACTIONS = [
+    # KEY (state) => VALUE (action)
+    {:cancelled => :open},
+    {:opened => :cancel}
+  ]
 
   belongs_to :user
   belongs_to :appointment

--- a/app/models/workflows/appointment_workflow.rb
+++ b/app/models/workflows/appointment_workflow.rb
@@ -2,6 +2,14 @@ module Workflows
   module AppointmentWorkflow
     extend ActiveSupport::Concern
 
+    def allowed_actions(scoped_statuses)
+      scoped_statuses.each_with_object([]) do |action, array|
+        if current_status.to_sym.in?(action.keys)
+          array << action[current_status.to_sym]
+        end
+      end
+    end
+
     def cancel!
       appointment_statuses.create!(
         name: :cancelled,
@@ -11,6 +19,19 @@ module Workflows
 
     def can_cancel?
       return unless current_status == "cancelled"
+
+      true
+    end
+
+    def open!
+      appointment_statuses.create!(
+        name: :opened,
+        user_id: creator_id
+      )
+    end
+
+    def can_open?
+      return unless current_status == "opened"
 
       true
     end

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -27,10 +27,8 @@ class AppointmentPolicy < ApplicationPolicy
     end
 
     def resolve
-      # Only show cancel option
       if is_agency? || is_customer?
-        # This should return :cancel
-        scope::ACTIONS.slice(:cancel).keys
+        scope::ACTIONS
       end
     end
 
@@ -45,7 +43,12 @@ class AppointmentPolicy < ApplicationPolicy
     is_customer?
   end
 
-  def cancel_appointment?
+  def cancel?
     is_agency? || is_customer?
+  end
+
+  # Permit any user to open an appointment
+  def open?
+    account_user.present?
   end
 end

--- a/app/views/appointments/show.html.erb
+++ b/app/views/appointments/show.html.erb
@@ -37,7 +37,7 @@
                   <div data-dropdown-target="menu" class="hidden left-0 md:right-0 absolute z-10 bg-white divide-y divide-gray-100 rounded-lg shadow dark:bg-gray-700 dark:divide-gray-600 block">
                     <div class="overflow-hidden bg-white border border-gray-200 rounded shadow-md z-20">
                       <div class="appointment-status-dropdown">
-                        <%= form_with url:  cancel_appointment_appointment_path(@appointment), method: :post do |form| %>
+                        <%= form_with url:  update_status_appointment_path(@appointment), method: :post do |form| %>
                         <button id="confirm-cancel" type="submit" class="hidden" data-controller="appointments" data-turbo-confirm="Are you sure?"></button>
                           <% @appointment_statuses.each do |status| %>
                             <div class="flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-600 py-3 px-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,8 +216,7 @@ Rails.application.routes.draw do
         get :time_finish
         put :update_time_finish
 
-        patch :status, to: "appointments#update_status"
-        post :cancel_appointment
+        post :update_status
       end
     end
     resources :customers

--- a/test/fixtures/appointments.yml
+++ b/test/fixtures/appointments.yml
@@ -97,6 +97,7 @@ one:
   language: one
   site: one
   creator: one
+  current_status: opened
 
 two:
   ref_number: MyString
@@ -109,7 +110,6 @@ two:
   admin_notes: MyText
   notes: MyText
   details: MyText
-  # status: false
   interpreter_type: 1
   billing_notes: MyText
   canceled_by: 1
@@ -123,3 +123,30 @@ two:
   language: two
   site: one
   creator: one
+  current_status: opened
+
+cancelled:
+  ref_number: MyString
+  start_time: 2022-11-21 15:04:46
+  finish_time: 2022-11-21 15:04:46
+  duration: 1
+  modality: 1
+  sub_type: 1
+  gender_req: 1
+  admin_notes: MyText
+  notes: MyText
+  details: MyText
+  interpreter_type: 1
+  billing_notes: MyText
+  canceled_by: 1
+  cancel_reason_code: 1
+  lock_version: 1
+  time_zone: MyString
+  confirmation_date: 2022-11-21 15:04:46
+  confirmation_phone: MyString
+  confirmation_notes: MyText
+  home_health_appointment: false
+  language: two
+  site: one
+  creator: one
+  current_status: cancelled

--- a/test/integration/account_users_test.rb
+++ b/test/integration/account_users_test.rb
@@ -111,11 +111,21 @@ class Jumpstart::AccountUsersTest < ActionDispatch::IntegrationTest
       sign_in @agency_admin.user
     end
 
-    test "agency account user has the cancel appointment option" do
+    test "agency admin has the cancel appointment option when an appointment is opened" do
       appointment = appointments(:one)
       get appointment_path(appointment)
       assert_select ".appointment-status-dropdown" do
-        assert_select "label", text: "Cancel"
+        assert_select "label", text: "Cancel", count: 1
+        assert_select "label", text: "Open", count: 0
+      end
+    end
+
+    test "agency admin cannot see cancel appointment option when an appointment is already cancelled" do
+      appointment = appointments(:cancelled)
+      get appointment_path(appointment)
+      assert_select ".appointment-status-dropdown" do
+        assert_select "label", text: "Cancel", count: 0
+        assert_select "label", text: "Open", count: 1
       end
     end
   end
@@ -125,11 +135,21 @@ class Jumpstart::AccountUsersTest < ActionDispatch::IntegrationTest
       sign_in @agency_member.user
     end
 
-    test "agency account member has the cancel appointment option" do
+    test "agency member has the cancel appointment option when an appointment is opened" do
       appointment = appointments(:one)
       get appointment_path(appointment)
       assert_select ".appointment-status-dropdown" do
-        assert_select "label", text: "Cancel"
+        assert_select "label", text: "Cancel", count: 1
+        assert_select "label", text: "Open", count: 0
+      end
+    end
+
+    test "agency member cannot see cancel appointment option when an appointment is already cancelled" do
+      appointment = appointments(:cancelled)
+      get appointment_path(appointment)
+      assert_select ".appointment-status-dropdown" do
+        assert_select "label", text: "Cancel", count: 0
+        assert_select "label", text: "Open", count: 1
       end
     end
   end
@@ -139,11 +159,21 @@ class Jumpstart::AccountUsersTest < ActionDispatch::IntegrationTest
       sign_in @customer_admin.user
     end
 
-    test "agency account user has the cancel appointment option" do
+    test "customer admin has the cancel appointment option when an appointment is opened" do
       appointment = appointments(:one)
       get appointment_path(appointment)
       assert_select ".appointment-status-dropdown" do
-        assert_select "label", text: "Cancel"
+        assert_select "label", text: "Cancel", count: 1
+        assert_select "label", text: "Open", count: 0
+      end
+    end
+
+    test "customer admin cannot see cancel appointment option when an appointment is already cancelled" do
+      appointment = appointments(:cancelled)
+      get appointment_path(appointment)
+      assert_select ".appointment-status-dropdown" do
+        assert_select "label", text: "Cancel", count: 0
+        assert_select "label", text: "Open", count: 1
       end
     end
   end
@@ -153,11 +183,21 @@ class Jumpstart::AccountUsersTest < ActionDispatch::IntegrationTest
       sign_in @customer_member.user
     end
 
-    test "agency account member has the cancel appointment option" do
+    test "customer member has the cancel appointment option when an appointment is opened" do
       appointment = appointments(:one)
       get appointment_path(appointment)
       assert_select ".appointment-status-dropdown" do
-        assert_select "label", text: "Cancel"
+        assert_select "label", text: "Cancel", count: 1
+        assert_select "label", text: "Open", count: 0
+      end
+    end
+
+    test "customer member cannot see cancel appointment option when an appointment is already cancelled" do
+      appointment = appointments(:cancelled)
+      get appointment_path(appointment)
+      assert_select ".appointment-status-dropdown" do
+        assert_select "label", text: "Cancel", count: 0
+        assert_select "label", text: "Open", count: 1
       end
     end
   end


### PR DESCRIPTION
## Description
Add ability for customers & agencies to open (cancelled) appointments


## Proof
https://user-images.githubusercontent.com/24237429/234078897-da9b1a3a-3b80-4cd0-b912-97eecc4b3d1c.mp4

