### PR TITLE
Feat: Additional appointment statuses to 'cancel'

### DIFF
--- a/app/models/appointment_status.rb
+++ b/app/models/appointment_status.rb
@@ -24,10 +24,21 @@ class AppointmentStatus < ApplicationRecord
   # after_update_commit -> { broadcast_replace_later_to self }
   # after_destroy_commit -> { broadcast_remove_to :appointment_statuses, target: dom_id(self, :index) }
 
-  ACTIONS = [
+  AGENCY_AND_CUSTOMER_ACTIONS = [
     # KEY (state) => VALUE (action)
+    {:created => :cancel},
+    {:offered => :cancel},
+    {:scheduled => :cancel},
     {:cancelled => :open},
+    {:verified => :cancel},
+    {:exported => :cancel},
     {:opened => :cancel}
+  ]
+
+  DEFAULT_ACTIONS = [
+    # KEY (state) => VALUE (action)
+    {:opened => :schedule},
+    {:scheduled => :open}
   ]
 
   belongs_to :user

--- a/app/models/workflows/appointment_workflow.rb
+++ b/app/models/workflows/appointment_workflow.rb
@@ -2,8 +2,17 @@ module Workflows
   module AppointmentWorkflow
     extend ActiveSupport::Concern
 
+    CANCELLABLE_STATUSES = [
+      "opened",
+      "offered",
+      "scheduled",
+      "verified",
+      "exported",
+      "created"
+    ].freeze
+
     def allowed_actions(scoped_statuses)
-      scoped_statuses.each_with_object([]) do |action, array|
+      Array.wrap(scoped_statuses).each_with_object([]) do |action, array|
         if current_status.to_sym.in?(action.keys)
           array << action[current_status.to_sym]
         end
@@ -17,23 +26,11 @@ module Workflows
       )
     end
 
-    def can_cancel?
-      return unless current_status == "cancelled"
-
-      true
-    end
-
     def open!
       appointment_statuses.create!(
         name: :opened,
         user_id: creator_id
       )
-    end
-
-    def can_open?
-      return unless current_status == "opened"
-
-      true
     end
   end
 end

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -27,8 +27,10 @@ class AppointmentPolicy < ApplicationPolicy
     end
 
     def resolve
-      if is_agency? || is_customer?
-        scope::ACTIONS
+      if is_agency? || is_customer? || account_user.admin?
+        scope::AGENCY_AND_CUSTOMER_ACTIONS
+      else
+        scope::DEFAULT_ACTIONS
       end
     end
 
@@ -44,7 +46,7 @@ class AppointmentPolicy < ApplicationPolicy
   end
 
   def cancel?
-    is_agency? || is_customer?
+    @record.current_status&.in?(Workflows::AppointmentWorkflow::CANCELLABLE_STATUSES)
   end
 
   # Permit any user to open an appointment


### PR DESCRIPTION
## Description
- Added "opened", "offered", "scheduled", "verified", "exported", "created" as cancellable statuses
- Fix undefined method on nil class error on appointments workflow

## Proof
https://user-images.githubusercontent.com/24237429/234350029-2b3062f8-5707-4481-8e0c-651a2a8453db.mp4

