### PR TITLE
Feat: allow interpreters to view finished appointments

### DIFF
--- a/app/controllers/interpreters_controller.rb
+++ b/app/controllers/interpreters_controller.rb
@@ -243,6 +243,8 @@ class InterpretersController < ApplicationController
       redirect_to(my_scheduled_details_interpreter_path(@appointment))
     elsif @appointment.status == "opened"
       redirect_to(my_public_details_interpreter_path(@appointment))
+    elsif @appointment.status == "finished"
+      redirect_to(my_scheduled_details_interpreter_path(@appointment))
     else
       redirect_to(interpreter_dashboard_path, alert: "Could not find appointment in an offered or scheduled status.")
     end


### PR DESCRIPTION
## Description
Added a condition where it shouldn't redirect if an appointment is finished


## Proof
https://user-images.githubusercontent.com/24237429/234351429-880d0579-ebbd-4a6e-806c-a6087ea45129.mp4




## Review Context
Interpreter user was being redirected when viewing a "finished" appointment
![image](https://user-images.githubusercontent.com/24237429/234351356-3e5502c7-59c5-479f-9a86-1793b4f32929.png)

