### PR TITLE
styles: form touch ups & fix state dropdown persistence

### DIFF
--- a/app/views/agencies/_tokani_form.html.erb
+++ b/app/views/agencies/_tokani_form.html.erb
@@ -55,7 +55,7 @@
         <div class="sm:col-span-2">
           <label for="region" class="block text-sm font-medium text-gray-700">State *</label>
           <div class="mt-1">
-            <%= physical_address.select :state, options_for_select(state_select_options, selected: physical_address.object.state), class: "mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-tokanisecondary-500 focus:outline-none focus:ring-tokanisecondary-500 sm:text-sm" %>
+            <%= physical_address.select :state, options_for_select(state_select_options, selected: physical_address.object&.state), include_blank: false, class: "mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-tokanisecondary-500 focus:outline-none focus:ring-tokanisecondary-500 sm:text-sm" %>
           </div>
         </div>
 
@@ -76,7 +76,7 @@
         </div>
         <div class="sm:col-span-3">
           <label for="street-address" class="block text-sm font-medium text-gray-700">Time zone *</label>
-          <%= agency_detail.select :time_zone, options_for_select(time_zone_select_options), class: "mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-tokanisecondary-500 focus:outline-none focus:ring-tokanisecondary-500 sm:text-sm" %> 
+          <%= agency_detail.select :time_zone, options_for_select(time_zone_select_options), class: "mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-tokanisecondary-500 focus:outline-none focus:ring-tokanisecondary-500 sm:text-sm" %>
         </div>
       </div>
     </div>
@@ -134,7 +134,7 @@
         </div>
       </div>
     </div>
-    
+
     <div class="pt-8">
       <div>
         <h3 class="text-lg font-medium leading-6 text-gray-900">URL Address</h3>
@@ -153,11 +153,11 @@
   <% end %>
   <div class="pt-5">
     <div class="flex justify-end">
-      <% if form.object.new_record? %> 
-        <%= link_to t("cancel"), agencies_path, class: "mr-3 inline-flex justify-center rounded-md border bg-transparent border-tokaniprimary-600 py-2 px-3.5 text-sm font-medium text-tokaniprimary-600 shadow-sm hover:bg-tokaniprimary-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %> 
+      <% if form.object.new_record? %>
+        <%= link_to t("cancel"), agencies_path, class: "mr-3 inline-flex justify-center rounded-md border bg-transparent border-tokaniprimary-600 py-2 px-3.5 text-sm font-medium text-tokaniprimary-600 shadow-sm hover:bg-tokaniprimary-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %>
         <%= form.button "Create Agency", class:"inline-flex justify-center rounded-md border border-transparent bg-tokanisecondary-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-tokanisecondary-700 focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %>
       <% else %>
-        <%= link_to t("cancel"), agency_path(@agency), class: "mr-3 inline-flex justify-center rounded-md border bg-transparent border-tokaniprimary-600 py-2 px-3.5 text-sm font-medium text-tokaniprimary-600 shadow-sm hover:bg-tokaniprimary-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %> 
+        <%= link_to t("cancel"), agency_path(@agency), class: "mr-3 inline-flex justify-center rounded-md border bg-transparent border-tokaniprimary-600 py-2 px-3.5 text-sm font-medium text-tokaniprimary-600 shadow-sm hover:bg-tokaniprimary-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %>
         <%= form.button "Update Agency", class:"inline-flex justify-center rounded-md border border-transparent bg-tokanisecondary-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-tokanisecondary-700 focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %>
       <% end %>
     </div>

--- a/app/views/agencies/agency_detail_form.html.erb
+++ b/app/views/agencies/agency_detail_form.html.erb
@@ -62,7 +62,7 @@
                       <div class="sm:col-span-2">
                         <label for="region" class="block text-sm font-medium text-gray-700">State *</label>
                         <div class="mt-1">
-                          <%= physical_address.select :state, options_for_select(state_select_options), class: "mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-tokanisecondary-500 focus:outline-none focus:ring-tokanisecondary-500 sm:text-sm" %>
+                          <%= physical_address.select :state, options_for_select(state_select_options, selected: physical_address.object&.state), include_blank: false, class: "mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-tokanisecondary-500 focus:outline-none focus:ring-tokanisecondary-500 sm:text-sm" %>
                         </div>
                       </div>
 

--- a/app/views/customers/_form.html.erb
+++ b/app/views/customers/_form.html.erb
@@ -9,23 +9,23 @@
         </div>
         <div class="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
           <div class="sm:col-span-3">
-            <label for="first-name" class="block text-sm font-medium text-gray-700">Company name</label>
+            <label for="first-name" class="block text-sm font-medium text-gray-700">Company name *</label>
             <div class="mt-1">
               <%= form.text_field :name, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "ex. Westside Hospital" %>
             </div>
           </div>
           <%= form.fields_for :customer_detail do |customer_detail| %>
           <div class="sm:col-span-3">
-            <label for="last-name" class="block text-sm font-medium text-gray-700">Category</label>
+            <label for="last-name" class="block text-sm font-medium text-gray-700">Category *</label>
             <div class="mt-1">
-              <%= customer_detail.select :customer_category_id,  options_from_collection_for_select(customer_categories, :id, :display_value, customer.customer_detail.customer_category_id ), {prompt: "Select A Customer Category..."}, {class: 'block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm' } %> 
+              <%= customer_detail.select :customer_category_id,  options_from_collection_for_select(customer_categories, :id, :display_value, customer.customer_detail.customer_category_id ), {prompt: "Select A Customer Category..."}, {class: 'block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm' } %>
             </div>
           </div>
           <% end %>
           <%= form.fields_for :physical_address do |physical_address| %>
           <%= physical_address.hidden_field :address_type, value: "physical" %>
           <div class="sm:col-span-3">
-            <label for="first-name" class="block text-sm font-medium text-gray-700">Street address 1</label>
+            <label for="first-name" class="block text-sm font-medium text-gray-700">Street address 1 *</label>
             <div class="mt-1">
               <%= physical_address.text_field :line1, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "ex. 1 Hospital Way" %>
             </div>
@@ -39,21 +39,21 @@
           </div>
 
           <div class="sm:col-span-3">
-            <label for="first-name" class="block text-sm font-medium text-gray-700">City</label>
+            <label for="first-name" class="block text-sm font-medium text-gray-700">City *</label>
             <div class="mt-1">
               <%= physical_address.text_field :city, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "ex. San Francisco" %>
             </div>
           </div>
 
           <div class="sm:col-span-3">
-            <label for="first-name" class="block text-sm font-medium text-gray-700">State</label>
+            <label for="first-name" class="block text-sm font-medium text-gray-700">State *</label>
             <div class="mt-1">
-              <%= physical_address.select :state, options_for_select(state_select_options), class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+              <%= physical_address.select :state, options_for_select(state_select_options, selected: physical_address.object&.state), include_blank: false, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
             </div>
           </div>
 
           <div class="sm:col-span-3">
-            <label for="first-name" class="block text-sm font-medium text-gray-700">Postal code</label>
+            <label for="first-name" class="block text-sm font-medium text-gray-700">Postal code *</label>
             <div class="mt-1">
               <%= physical_address.text_field :postal_code, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "ex. 70707" %>
             </div>
@@ -68,14 +68,14 @@
         <div class="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
           <%= form.fields_for :customer_detail do |customer_detail| %>
           <div class="sm:col-span-3">
-            <label for="first-name" class="block text-sm font-medium text-gray-700">Contact's name</label>
+            <label for="first-name" class="block text-sm font-medium text-gray-700">Contact's name *</label>
             <div class="mt-1">
               <%= customer_detail.text_field :contact_name, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "ex. Jerry" %>
             </div>
           </div>
 
           <div class="sm:col-span-3">
-            <label for="email" class="block text-sm font-medium text-gray-700">Email address</label>
+            <label for="email" class="block text-sm font-medium text-gray-700">Email address *</label>
             <div class="mt-1">
               <%= customer_detail.text_field :email, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "ex. name@email.com" %>
             </div>
@@ -89,7 +89,7 @@
           </div>
 
           <div class="sm:col-span-2">
-            <label for="street-address" class="block text-sm font-medium text-gray-700">Phone number</label>
+            <label for="street-address" class="block text-sm font-medium text-gray-700">Phone number *</label>
             <div class="mt-1">
               <%= customer_detail.text_field :phone, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "ex. 123-456-7890" %>
             </div>
@@ -110,12 +110,12 @@
           <legend class="sr-only">Appointment Modalitites</legend>
           <div class="relative flex items-start">
             <div class="flex h-5 items-center">
-              <%= customer_detail.check_box :appointments_in_person, class:"h-4 w-4 rounded border-gray-300 text-tokanisecondary-600 focus:ring-tokanisecondary-500" %>  
+              <%= customer_detail.check_box :appointments_in_person, class:"h-4 w-4 rounded border-gray-300 text-tokanisecondary-600 focus:ring-tokanisecondary-500" %>
             </div>
             <div class="ml-3 text-sm">
               <%= customer_detail.label :appointments_in_person, class:"font-medium text-gray-700" %>
               <p id="in_person_appointments" class="text-gray-500">This customer books in-person appointments.</p>
-            </div> 
+            </div>
           </div>
           <div class="relative flex items-start">
             <div class="flex h-5 items-center">
@@ -147,8 +147,8 @@
           </div>
         </div>
       </div>
-      
-      <div class="bg-gray-50 px-4 py-3 text-right sm:px-6">        
+
+      <div class="bg-gray-50 px-4 py-3 text-right sm:px-6">
         <% if form.object.new_record? %>
           <%= link_to t("cancel"), customers_path, class:"inline-flex justify-center rounded-md border bg-transparent border-tokaniprimary-600 py-2 px-3.5 text-sm font-medium text-tokaniprimary-600 shadow-sm hover:bg-tokaniprimary-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %>
         <% else %>

--- a/app/views/recipients/_form.html.erb
+++ b/app/views/recipients/_form.html.erb
@@ -19,7 +19,7 @@
                 <%= form.text_field :email, class: "mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-tokanisecondary-500 focus:outline-none focus:ring-tokanisecondary-500 sm:text-sm" %>
               </div>
               <div class="col-span-6 sm:col-span-3">
-                <%= form.label :srn, class: "block text-sm font-medium text-gray-700" %>
+                <%= form.label :srn, "Service Recipient Number", class: "block text-sm font-medium text-gray-700" %>
                 <%= form.text_field :srn, class: "mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 shadow-sm focus:border-tokanisecondary-500 focus:outline-none focus:ring-tokanisecondary-500 sm:text-sm" %>
               </div>
               <div class="col-span-6 sm:col-span-3">
@@ -33,23 +33,23 @@
               <div class="col-span-6 sm:col-span-3 mt-4">
                 <div class="relative flex items-start">
                   <div class="flex h-5 items-center">
-                    <%= form.check_box :allow_text, class:"h-4 w-4 rounded border-gray-300 text-tokanisecondary-600 focus:ring-tokanisecondary-500" %>  
+                    <%= form.check_box :allow_text, class:"h-4 w-4 rounded border-gray-300 text-tokanisecondary-600 focus:ring-tokanisecondary-500" %>
                   </div>
                   <div class="ml-3 text-sm">
                     <%= form.label :allow_text, class:"font-medium text-gray-700" %>
                     <p id="allow_text" class="text-gray-500">This recipient gets text notifications.</p>
-                  </div> 
+                  </div>
                 </div>
               </div>
               <div class="col-span-6 sm:col-span-3 mt-4">
                 <div class="relative flex items-start">
                   <div class="flex h-5 items-center">
-                    <%= form.check_box :allow_email, class:"h-4 w-4 rounded border-gray-300 text-tokanisecondary-600 focus:ring-tokanisecondary-500" %>  
+                    <%= form.check_box :allow_email, class:"h-4 w-4 rounded border-gray-300 text-tokanisecondary-600 focus:ring-tokanisecondary-500" %>
                   </div>
                   <div class="ml-3 text-sm">
                     <%= form.label :allow_email, class:"font-medium text-gray-700" %>
                     <p id="allow_email" class="text-gray-500">This recipient gets email notifications.</p>
-                  </div> 
+                  </div>
                 </div>
               </div>
 
@@ -57,7 +57,7 @@
                 <div class="col-span-3 sm:col-span-6">
                   <div class="form-group">
                     <%= form.label "Customer*", class: "block text-sm font-medium text-gray-700" %>
-                    <%= form.select :customer_id,  options_from_collection_for_select(customers, :id, :name, recipient.customer_id ), {prompt: "Select A Customer..."}, {class: 'form-control',  data: {action: 'change->select-group#updateSelectRemote', select_group_url_param: select_list_sites_path, select_group_select_key_param: 'customer_id', select_group_select_update_target_param: 'provider_site_id', select_group_select_clear_target_param: 'provider_department_id' }} %> 
+                    <%= form.select :customer_id,  options_from_collection_for_select(customers, :id, :name, recipient.customer_id ), {prompt: "Select A Customer..."}, {class: 'form-control',  data: {action: 'change->select-group#updateSelectRemote', select_group_url_param: select_list_sites_path, select_group_select_key_param: 'customer_id', select_group_select_update_target_param: 'provider_site_id', select_group_select_clear_target_param: 'provider_department_id' }} %>
                   </div>
                 </div>
               <% end %>
@@ -72,8 +72,8 @@
             <% end %>
             <%= form.button button_text(form.send(:submit_default_value)), class:"inline-flex justify-center rounded-md border border-transparent bg-tokanisecondary-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-tokanisecondary-700 focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %>
           </div>
-        </div> 
-      </div> 
+        </div>
+      </div>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
## Description
- Spell out Service Recipient Number, on recipient form
- Put asterisk next to phone number on new-customer form.
- Make the state persist through validations, on all forms where there is state/address (it currently resets if there is a validation error so it needs to be chosen again)
- Add asterisks to new-customer form for validated fields


## Proof
https://user-images.githubusercontent.com/24237429/234633382-a75315f7-c6e1-45b5-aeea-a436c1eabb01.mp4
