### PR TITLE
Fix for an ActiveJob::SerializationError in CreateCustomerOwnerUserAccountJob

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -71,7 +71,7 @@ class Customer < Account
 
       AgencyCustomerCreationMailer.welcome(user, self).deliver_later
     else
-      raise "Could not save User in Customer#create_user_and_owner - #{user.errors.full_messages.join('; ')}"
+      raise "Could not save User in Customer#create_user_and_owner - #{user.errors.full_messages.join("; ")}"
     end
   end
 


### PR DESCRIPTION
## Description

Wraps the user creation here in a save check and raises an error if there is a reason the User cannot be saved.

Fix for this error: https://app.honeybadger.io/projects/105551/faults/95431963

At least now we will be notified about what the error is, so we can address that issue if/when it arises again.
