### PR TITLE
Feat: Add all appointment statuses as options in filter

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -15,7 +15,7 @@ class AppointmentsController < ApplicationController
     @appointments = AppointmentsFilteringService.new(current_user, filtering_params, @appointments).fetch_appointments
     @pagy, @appointments = pagy(@appointments.sort_by_params(params[:sort], sort_direction))
 
-    @statuses = ["all", "scheduled", "finished"]
+    @statuses = AppointmentStatus.names.keys.append("all")
     @customer_names = @appointments.map(&:customer).pluck(:name).uniq
     @modalities = Appointment.modalities.keys
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -123,7 +123,7 @@ class Appointment < ApplicationRecord
   }
 
   scope :by_status, ->(status) { where(status: status) }
-  scope :by_appointment_specific_status, ->(name) { joins(:appointment_statuses).where(appointment_statuses: {name: name}) }
+  scope :by_appointment_specific_status, ->(current_status) { where current_status: }
   scope :by_customer_name, ->(name) { includes(:customer).where(customer: {name: name}) }
   scope :sort_by_account_name, -> { includes(:customer).order("accounts.name ASC") }
 


### PR DESCRIPTION
## Description
- Add all appointment_statuses.names as options in dropdown filter
- Update by_appointment_specific_status method to query from appointments.current_status instead of querying from appointment_statuses


## Proof
https://user-images.githubusercontent.com/24237429/236023149-786aa28a-3b20-481c-bbd6-217193a01bf9.mp4




## notes
I remember this being a spec in our previous conversations. Currently interpreter users do not have the ability to filter statuses:

view:
![image](https://user-images.githubusercontent.com/24237429/236024006-e6391c87-65fb-48c8-938b-ddd6db13febc.png)
policy:
![image](https://user-images.githubusercontent.com/24237429/236024475-9c7e36a3-f2e5-405f-a14f-66baf252ac7f.png)

Just want to confirm if this is still the expected behavior
