### PR TITLE
Fix: customer layout rendering upon interpreter search

### DIFF
--- a/app/controllers/interpreters_controller.rb
+++ b/app/controllers/interpreters_controller.rb
@@ -5,7 +5,7 @@ class InterpretersController < ApplicationController
   # Uncomment to enforce Pundit authorization
   before_action :verify_authorized, except: [:search, :search_assigned_int]
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-  before_action :verify_interpreter_detail
+  before_action :verify_interpreter_detail, except: [:search, :search_assigned_int]
 
   before_action :set_interpreter, only: [:show, :edit, :update, :destroy, :availabilities, :update_timezone]
   before_action :set_appointment, only: [:my_public_details, :my_scheduled_details, :my_assigned_details, :claim_public,


### PR DESCRIPTION
## Description
Bug: layout is rendering upon searching interpreter
Resolution: found out that we recently put a verification for interpreter details on all interpreters_controller actions. I just needed to exempt the :search methods.


## Proof
https://user-images.githubusercontent.com/24237429/236036524-d94449d9-f98b-4b41-9123-56d95becb3be.mp4

