### PR TITLE
 fix video meeting link on appointment form for video modality

### DIFF
--- a/app/views/appointments/_form.html.erb
+++ b/app/views/appointments/_form.html.erb
@@ -63,7 +63,6 @@
                 <%= form.select :language_id, options_from_collection_for_select(languages, :id, :name, appointment.language_id), {prompt: "Please select A Language"}, {class: 'form-control', data: {interpreter_autocomplete_target: "languageId"}}  %>
               </div>
             </div>
-          </div>
             <div class="col-span-12 sm:col-span-12 lg:col-span-3">
               <div class="form-group">
                 <%= form.label :video_link, "Video Link (only Video modality)", class: "block text-sm font-medium text-gray-700" %>
@@ -74,7 +73,6 @@
                 <% end %>
               </div>
             </div>
-
             <div class="col-span-6 sm:col-span-6 lg:col-span-3">
               <div class="form-group">
                 <%= form.label :requestor_id, "Requestor*", class: "block text-sm font-medium text-gray-700" %>


### PR DESCRIPTION
## Description
- closes https://github.com/SuperDupr/tokani/issues/486
- JS wasnt working properly, incorrect closing div


https://user-images.githubusercontent.com/2928409/236292977-d752d1db-da11-4968-8013-2a18d8a36318.mov

