### PR TITLE
Make timeoutable time-out time a year in development environment

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -188,10 +188,10 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  if Rails.env.development?
-    config.timeout_in = 365.days
+  config.timeout_in = if Rails.env.development?
+    365.days
   else
-    config.timeout_in = 15.minutes
+    15.minutes
   end
 
   # ==> Configuration for :lockable


### PR DESCRIPTION
## Description

Makes it so that in the development environment, you only timeout after a year has passed. In all other environments, it's still 15 minutes.

## Proof

No screenshots, but I stepped away for 30 minutes and came back and my sessions were still active.