### PR TITLE
TK-258 - Do not allow last default active rate to be de-activated

### DIFF
--- a/app/models/bill_rate.rb
+++ b/app/models/bill_rate.rb
@@ -161,10 +161,6 @@ class BillRate < ApplicationRecord
     end
     true
   end
-  
-  def is_default?
-    default_rate
-  end
 
   def must_select_at_least_one_modality
     return if modality_list.present?

--- a/app/models/pay_rate.rb
+++ b/app/models/pay_rate.rb
@@ -85,10 +85,6 @@ class PayRate < ApplicationRecord
     true
   end
 
-  def is_default?
-    default_rate
-  end
-
   def must_select_at_least_one_modality
     return if modality_list.present?
 


### PR DESCRIPTION
## Description

Added validations upon update hooks, such that if the last default rate (Pay or Bill) is deactivated, it throws a validation error message.


## Proof

<img width="1339" alt="Screen Shot 2023-05-05 at 9 52 28 PM" src="https://user-images.githubusercontent.com/356/236600655-38bdcd3d-f7f9-46ba-9556-2dc5cbc8c344.png">

