### PR TITLE
TK-265 - Fix Edit Appointment issue with general/specific radio buttons

### DIFF
--- a/app/javascript/controllers/radio_button_controller.js
+++ b/app/javascript/controllers/radio_button_controller.js
@@ -1,9 +1,28 @@
 import { Controller } from "@hotwired/stimulus"
 
-
 export default class extends Controller {
-  // static values = { message: String};
-  static targets = ["fieldset"]
+  static targets = ["fieldset", "typeselected"]
+
+  // This method is very specific to the Edit Appointment page. Like the comment below says,
+  // this could be moved to a dedicated controller if we need a more generic radio button controller.
+  connect() {
+    const selectedFieldSet = this.typeselectedTarget
+
+    this.fieldsetTargets.forEach( fs => {
+      if (fs.id == this.typeselectedTarget.value) {
+        fs.disabled = false
+        fs.querySelectorAll('div.multiselect__container').forEach(so => {so.disabled = false })
+        fs.querySelectorAll('input').forEach(so => {so.disabled = false })
+        fs.querySelectorAll('.selected-option', 'div.input-group').forEach(so => {so.classList.remove('disabled') })
+      } else {
+        fs.disabled = true
+        fs.querySelectorAll('div.multiselect__container').forEach(so => {so.disabled = true })
+        fs.querySelectorAll('input').forEach(so => {so.disabled = true })
+        fs.querySelectorAll('input').forEach(so => {so.value = "" })
+        fs.querySelectorAll('.selected-option').forEach(so => {so.classList.add('disabled')})
+      }
+    })
+  }
 
   selectFieldset(event) {
     
@@ -27,6 +46,7 @@ export default class extends Controller {
     this.clearFields(event)
 
   }
+
   //This is super specific for the default and language selections on pay and bill rates 
   //May need to move to own controller at some point or re-work 
   clearFields(event) {

--- a/app/views/appointments/_appointment_requests.html.erb
+++ b/app/views/appointments/_appointment_requests.html.erb
@@ -1,7 +1,8 @@
 
       <div class="" data-controller='radio-button'>
+        <%= hidden_field_tag '_type_selected', (specific_int ? 'specific_interpreters' : 'general_request'), data: {radio_button_target: "typeselected"} %>
         <div class="relative flex items-start">
-            <div class="flex h-6 items-center"> 
+            <div class="flex h-6 items-center">
                 <%= radio_button_tag 'appointment[interpreter_type]', 'general', !specific_int, class: 'h-4 w-4 border-gray-300 text-tokanisecondary-600 focus:ring-tokanisecondary-500', data: {action: "click->radio-button#selectFieldset", radio_button_fieldset_param: "general_request"} %>
             </div>
             <div class="ml-3 text-sm leading-6">


### PR DESCRIPTION
## Description

When the Edit Appointment page is loaded, make sure the General Interpreter fields are ENabled if Gen. Interpreter request was previously selected, an the specific interprter field should be disabled. Vice versa if the opposite is selected. Also tested on the New Appointment page and that still works as expected.


## Proof

After loading the page w/ General Interpreter selected:

<img width="710" alt="Screen Shot 2023-05-09 at 12 08 36 AM" src="https://user-images.githubusercontent.com/356/237021098-adeaf651-27bc-44d9-8442-60108d9263e8.png">

