### PR TITLE
Add authentication to the Sites controller

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,6 +1,7 @@
 class SitesController < ApplicationController
   include CurrentHelper
 
+  before_action :authenticate_user!
   before_action :set_site, only: [:show, :edit, :update, :destroy]
 
   # Uncomment to enforce Pundit authorization


### PR DESCRIPTION
## Description

If a user had gotten signed out and then tried to access any page on the Sites controller, it would likely throw an error. Add a before action authetication call to ensure there's a logged in user that can access the controller's actions.

Resolves: https://appsignal.com/tokani/sites/64594e1cd2a5e44490c82b64/exceptions/incidents/3
