### PR TITLE
Fix: agency admins unable to create an interpreter error

### DIFF
--- a/app/controllers/interpreter_details_controller.rb
+++ b/app/controllers/interpreter_details_controller.rb
@@ -124,6 +124,8 @@ class InterpreterDetailsController < ApplicationController
   end
 
   def authenticate_interpreter_user!
+    return if current_account_user.agency_admin?
+
     redirect_to "/", alert: "Unauthorized access for non-interpreter users." unless current_account_user.interpreter?
   end
 

--- a/app/controllers/interpreters_controller.rb
+++ b/app/controllers/interpreters_controller.rb
@@ -393,7 +393,8 @@ class InterpretersController < ApplicationController
         :address,
         :city,
         :state,
-        :zip
+        :zip,
+        :time_zone
       ]
     )
   end

--- a/app/policies/interpreter_detail_policy.rb
+++ b/app/policies/interpreter_detail_policy.rb
@@ -7,19 +7,19 @@ class InterpreterDetailPolicy < ApplicationPolicy
   end
 
   def edit?
-    is_admin_or_interpreter?
+    is_admin_or_interpreter? || is_agency_admin?
   end
 
   def new?
-    is_admin_or_interpreter?
+    is_admin_or_interpreter? || is_agency_admin?
   end
 
   def create?
-    is_admin_or_interpreter?
+    is_admin_or_interpreter? || is_agency_admin?
   end
 
   def update?
-    is_admin_or_interpreter?
+    is_admin_or_interpreter? || is_agency_admin?
   end
 
   def destroy?
@@ -30,9 +30,17 @@ class InterpreterDetailPolicy < ApplicationPolicy
     is_admin_or_interpreter?
   end
 
+  def interpreter_detail_show_account_nav?
+    account_user.interpreter?
+  end
+
   private
 
   def is_admin_or_interpreter?
     account_user.admin? || account_user.interpreter?
+  end
+
+  def is_agency_admin?
+    account_user.agency_admin?
   end
 end

--- a/app/views/interpreter_details/edit.html.erb
+++ b/app/views/interpreter_details/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-wrap my-4 lg:px-4">
   <div class="lg:w-1/4 w-full p-4">
-    <%= render partial: "shared/account_navbar" %>
+    <%= render partial: "shared/account_navbar" if policy(:interpreter_detail).interpreter_detail_show_account_nav? %>
   </div>
 
   <%= content_for :title, t("shared.scaffold.edit.title", model: "Interpreter Detail") %>

--- a/app/views/interpreter_details/show.html.erb
+++ b/app/views/interpreter_details/show.html.erb
@@ -2,7 +2,7 @@
 <%= turbo_stream_from @interpreter_detail %>
 <div class="flex flex-wrap my-4 lg:px-4">
   <div class="w-full mb-4 lg:w-1/4 lg:p-4">
-    <%= render partial: "shared/account_navbar" %>
+    <%= render partial: "shared/account_navbar" if policy(:interpreter_detail).interpreter_detail_show_account_nav? %>
   </div>
 
   <div class="w-full lg:w-3/4 lg:p-4">

--- a/app/views/interpreters/_form.html.erb
+++ b/app/views/interpreters/_form.html.erb
@@ -89,10 +89,19 @@
                     </div>
                   </div>
                 </div>
+
+                <div class="col-span-6 sm:col-span-3">
+                  <div class="form-group">
+                      <%= interpreter_detail.label "Time Zone*" , class: "block text-sm font-medium text-gray-700" %>
+                      <%= interpreter_detail.select :time_zone, options_for_select(time_zone_select_options), {class: 'form-control' } %>
+                    </div>
+                  </div>
+                </div>
+
             <% end %>
             <% if !form.object.new_record? %>
             <div class="col-span-12 sm:col-span-12">
-             
+
               <div data-controller="multiselect" data-multiselect-items-value='<%= @languages_json %>' data-placeholder="Select Languages for this Interpreter" <%= raw selected_languages(@interpreter.new_record?, @interpreter_languages_json) %>>
               <!-- <div data-controller="multiselect" data-multiselect-items-value='<%= @languages_json %>' data-placeholder="Select Languages" data-multiselect-selected-value='<%= raw @interpreter_languages_json %>'>> -->
                 <select multiple="multiple" class="hidden multiselect__hidden" data-multiselect-target="hidden" name="user[language_ids][]" id="user_language_ids" style="display: none;"></select>
@@ -110,7 +119,7 @@
             <% action = form.object.new_record? ? "Create" : "Update" %>
             <%= form.button button_text("#{action} Interpreter"), class:"inline-flex justify-center rounded-md border border-transparent bg-tokanisecondary-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-tokanisecondary-700 focus:outline-none focus:ring-2 focus:ring-tokanisecondary-500 focus:ring-offset-2" %>
           </div>
-        </div> 
+        </div>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
## Description
Issue: interpreter/new gets redirected to interpreter_details_new which has a verification for authorizing (non-interpreter) users
Solution: Skip verification for agency_admin users

- add a verification skip on interpreter_details controller for agency_admins
- update InterpreterDetail policy to allow agency_admin authorization
- hide account/_navbar on interpreter details form as an agency_admin
- add time_zone field (interpreter detail required) to interpreters/new form


## Proof
<!-- Attach screenshots or other proof that the changes made are effective. -->

https://github.com/SuperDupr/tokani/assets/24237429/c04f14e4-77fa-4899-adf5-91c8cc5ffa3a


