### PR TITLE
TK-268 - Add ability to resend confirmation emails to requestors

### DIFF
--- a/app/controllers/requestors_controller.rb
+++ b/app/controllers/requestors_controller.rb
@@ -112,6 +112,7 @@ class RequestorsController < ApplicationController
 
     respond_to do |format|
       if @requestor.save
+        @requestor.update(confirmed_at: nil)
         # AccountUser.create!(account_id: current_account.id, user_id: @requestor.id, roles: req_type)
         AccountUser.create!(account_id: @requestor.requestor_detail.customer_id, user_id: @requestor.id, roles: req_type)
         CustomerRequestor.create!(requestor_id: @requestor.id, customer_id: @requestor.requestor_detail.customer_id)
@@ -119,7 +120,6 @@ class RequestorsController < ApplicationController
         format.html { redirect_to requestor_path(@requestor), notice: "Requestor was successfully created." }
         format.json { render :show, status: :created, location: @requestor }
       else
-
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @requestor.errors, status: :unprocessable_entity }
       end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,5 +1,20 @@
 class Users::RegistrationsController < Devise::RegistrationsController
+  include CurrentHelper
   invisible_captcha only: :create
+
+  def resend_confirmation
+    if !agency_logged_in?
+      return redirect_to "/", alert: "Please sign in to do that."
+    end
+
+    user = User.find_by(id: params[:id])
+    if user.present?
+      user.send_confirmation_instructions
+      redirect_back fallback_location: root_url, notice: "Confirmation instructions successfully sent."
+    else
+      redirect_back fallback_location: root_url, alert: "Unable to send confirmations instructions. User not found."
+    end
+  end
 
   protected
 

--- a/app/views/requestors/index.html.erb
+++ b/app/views/requestors/index.html.erb
@@ -26,7 +26,10 @@
                     <th scope="col" class="hidden px-3 py-3.5 text-left text-sm uppercase font-semibold text-gray-900 lg:table-cell">Site</th>
                     <th scope="col" class="hidden px-3 py-3.5 text-left text-sm uppercase font-semibold text-gray-900 sm:table-cell">Role</th>
                     <th scope="col" class="px-3 py-3.5 text-left text-sm uppercase font-semibold text-gray-900">Phone</th>
-                    <th scope="col" class="px-3 py-3.5 text-left text-sm uppercase font-semibold text-gray-900">Edit</th>
+                    <th scope="col" class="px-3 py-3.5 text-left text-sm uppercase font-semibold text-gray-900"></th>
+                    <% if agency_logged_in? %>
+                      <th scope="col" class="px-3 py-3.5 text-left text-sm uppercase font-semibold text-gray-900" style="min-widtH: 260px;"></th>
+                    <% end %>
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-200 bg-white">
@@ -50,7 +53,12 @@
                     <td class="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell"><%= requestor.requestor_detail.requestor_type.titleize %></td>
                     <td class="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell"><%= requestor.requestor_detail.primary_phone %></td>
                     <td class="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell">
-                      <a href="<%= edit_requestor_path(requestor) %>" class="text-tokanisecondary-600 hover:text-tokanisecondary-900">Edit<span class="sr-only">, <%= requestor.id %></span></a>
+                      <a href="<%= edit_requestor_path(requestor) %>" class="inline-block text-tokanisecondary-600 hover:text-tokanisecondary-900">Edit<span class="sr-only">, <%= requestor.id %></span></a>
+                    </td>
+                    <td class="hidden px-3 py-4 text-sm text-gray-500 sm:table-cell">
+                      <% if agency_logged_in? && !requestor.confirmed? %>
+                        <%= link_to "Not confirmed. Resend email?", "/users/registrations/#{requestor.id}/resend_confirmation", class: "inline-block items-center justify-center rounded-lg border bg-transparent border-red-500 py-2 px-3.5 text-sm font-medium text-red-600 shadow-sm hover:bg-red-600 hover:text-white focus:outline-none", data: { turbo_method: :post, turbo_confirm: t("are_you_sure") } %>
+                      <% end %>
                     </td>
                   </tr>
                 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
     get "session/otp", to: "sessions#otp"
     get "/check_session_timeout" => "session_timeout#check_session_timeout"
     get "/session_timeout" => "session_timeout#render_timeout"
+    post "/users/registrations/:id/resend_confirmation" => "users/registrations#resend_confirmation"
   end
 
   resources :announcements, only: [:index, :show]


### PR DESCRIPTION
## Description

Adds the ability for agency admins to resend confirmation instruction emails to requestors.

Note: During my testing, I discovered that requestors were being created with their "confirmed_at" field already set:

<img width="1480" alt="Screen Shot 2023-05-09 at 8 24 31 PM" src="https://github.com/SuperDupr/tokani/assets/356/ad33a5d3-c180-434b-87d8-acd1fbfcd702">

I did not see anything in our code that was causing this. To work around this, I added an update to the requestor on the create method on the Requestors controller, setting the "confirmed_at" field back to nil.

The button/text for "Not confirmed. Resend email?" is a bit large/long. I was not able to figure out how to make it smaller / more compact.

## Proof

<img width="1201" alt="Screen Shot 2023-05-09 at 10 20 24 PM" src="https://github.com/SuperDupr/tokani/assets/356/f05ed61c-b3e8-4451-a8c6-3d2e20d7d9e4">

