### PR TITLE
feature: add 'scheduled' to allowable statuses to schedule

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -398,7 +398,7 @@ class Appointment < ApplicationRecord
   end
 
   def can_schedule?
-    status == "opened" || status == "offered"
+    status.in? ["opened", "offered", "scheduled"]
   end
   # commenting this out because standardrb showed two methods in this model with this name
   # def end_time


### PR DESCRIPTION
## Description
Add 'Scheduled' status to allowable statuses for an appointment to be scheduled. This condition allows the schedule appointment icon show for these statuses.

This resolves issue #503 

## Proof
![image](https://github.com/SuperDupr/tokani/assets/24237429/bdfaf35b-9bf8-4a40-9ca3-4545ff21fe2d)
